### PR TITLE
Add google backport package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN set -ex \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && pip install -r /requirements.txt \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
+    && pip install apache-airflow-backport-providers-google \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf \

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ google-auth-oauthlib==0.4.1
 google-cloud==0.34.0
 google-cloud-bigquery==1.23.1
 google-cloud-core==1.2.0
+google-cloud-datacatalog==0.7.0
 google-cloud-firestore==1.6.2
 google-cloud-storage==1.25.0
 google-resumable-media==0.5.0


### PR DESCRIPTION
I need a Google Data Catalog provider support, it is not distributed as a part of Airflow itself, but only as additional backport package for Google providers (some of the providers they created only for Airflow 2.0 but with this package they make it available also for Airflow 1.x)

Details are here https://github.com/apache/airflow/blob/375d1ca229464617780623c61c6e8a1bf570c87f/airflow/providers/google/README.md